### PR TITLE
All screens adapted in Portrait mode

### DIFF
--- a/src/functions/UI_definitions.lua
+++ b/src/functions/UI_definitions.lua
@@ -3572,63 +3572,63 @@ function G.UIDEF.view_deck(unplayed_only)
     }}
     return t
   else
-  local t = 
-  {n=G.UIT.ROOT, config={align = "cm", colour = G.C.CLEAR}, nodes={
-    {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={}},
-    {n=G.UIT.R, config={align = "cm"}, nodes={
-      {n=G.UIT.C, config={align = "cm", minw = 1.5, minh = 2, r = 0.1, colour = G.C.BLACK, emboss = 0.05}, nodes={
-        {n=G.UIT.C, config={align = "cm", padding = 0.1}, nodes={
-          {n=G.UIT.R, config={align = "cm", r = 0.1, colour = G.C.L_BLACK, emboss = 0.05, padding = 0.15}, nodes={
-            {n=G.UIT.R, config={align = "cm"}, nodes={
-              {n=G.UIT.O, config={object = DynaText({string = G.GAME.selected_back.loc_name, colours = {G.C.WHITE}, bump = true, rotate = true, shadow = true, scale = 0.6 - string.len(G.GAME.selected_back.loc_name)*0.01})}},
+    local t = 
+    {n=G.UIT.ROOT, config={align = "cm", colour = G.C.CLEAR}, nodes={
+      {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={}},
+      {n=G.UIT.R, config={align = "cm"}, nodes={
+        {n=G.UIT.C, config={align = "cm", minw = 1.5, minh = 2, r = 0.1, colour = G.C.BLACK, emboss = 0.05}, nodes={
+          {n=G.UIT.C, config={align = "cm", padding = 0.1}, nodes={
+            {n=G.UIT.R, config={align = "cm", r = 0.1, colour = G.C.L_BLACK, emboss = 0.05, padding = 0.15}, nodes={
+              {n=G.UIT.R, config={align = "cm"}, nodes={
+                {n=G.UIT.O, config={object = DynaText({string = G.GAME.selected_back.loc_name, colours = {G.C.WHITE}, bump = true, rotate = true, shadow = true, scale = 0.6 - string.len(G.GAME.selected_back.loc_name)*0.01})}},
+              }},
+              {n=G.UIT.R, config={align = "cm", r = 0.1, padding = 0.1, minw = 2.5, minh = 1.3, colour = G.C.WHITE, emboss = 0.05}, nodes={
+                {n=G.UIT.O, config={object = UIBox{
+                  definition = G.GAME.selected_back:generate_UI(nil,0.7, 0.5, G.GAME.challenge),
+                  config = {offset = {x=0,y=0}}
+                }}}
+              }}
             }},
-            {n=G.UIT.R, config={align = "cm", r = 0.1, padding = 0.1, minw = 2.5, minh = 1.3, colour = G.C.WHITE, emboss = 0.05}, nodes={
-              {n=G.UIT.O, config={object = UIBox{
-                definition = G.GAME.selected_back:generate_UI(nil,0.7, 0.5, G.GAME.challenge),
-                config = {offset = {x=0,y=0}}
-              }}}
+            {n=G.UIT.R, config={align = "cm", r = 0.1, outline_colour = G.C.L_BLACK, line_emboss = 0.05, outline = 1.5}, nodes={
+              {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.07}, nodes={
+                  {n=G.UIT.O, config={object = DynaText({string = {{string = localize('k_base_cards'), colour = G.C.RED}, modded and {string = localize('k_effective'), colour = G.C.BLUE} or nil}, colours = {G.C.RED}, silent = true,scale = 0.4,pop_in_rate = 10, pop_delay = 4})}}
+              }},
+              {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.1}, nodes={
+                tally_sprite({x=1,y=0},{{string = ''..ace_tally, colour = flip_col},{string =''..mod_ace_tally, colour = G.C.BLUE}}, {localize('k_aces')}),--Aces
+                tally_sprite({x=2,y=0},{{string = ''..face_tally, colour = flip_col},{string =''..mod_face_tally, colour = G.C.BLUE}}, {localize('k_face_cards')}),--Face
+                tally_sprite({x=3,y=0},{{string = ''..num_tally, colour = flip_col},{string =''..mod_num_tally, colour = G.C.BLUE}}, {localize('k_numbered_cards')}),--Numbers
+              }},
+              {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.1}, nodes={
+                tally_sprite({x=3,y=1}, {{string = ''..suit_tallies['Spades'], colour = flip_col},{string =''..mod_suit_tallies['Spades'], colour = G.C.BLUE}}, {localize('Spades', 'suits_plural')}),
+                tally_sprite({x=0,y=1}, {{string = ''..suit_tallies['Hearts'], colour = flip_col},{string =''..mod_suit_tallies['Hearts'], colour = G.C.BLUE}}, {localize('Hearts', 'suits_plural')}),
+              }},
+              {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.1}, nodes={
+                tally_sprite({x=2,y=1}, {{string = ''..suit_tallies['Clubs'], colour = flip_col},{string =''..mod_suit_tallies['Clubs'], colour = G.C.BLUE}}, {localize('Clubs', 'suits_plural')}),
+                tally_sprite({x=1,y=1}, {{string = ''..suit_tallies['Diamonds'], colour = flip_col},{string =''..mod_suit_tallies['Diamonds'], colour = G.C.BLUE}}, {localize('Diamonds', 'suits_plural')}),
+              }},
             }}
           }},
-          {n=G.UIT.R, config={align = "cm", r = 0.1, outline_colour = G.C.L_BLACK, line_emboss = 0.05, outline = 1.5}, nodes={
-            {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.07}, nodes={
-                {n=G.UIT.O, config={object = DynaText({string = {{string = localize('k_base_cards'), colour = G.C.RED}, modded and {string = localize('k_effective'), colour = G.C.BLUE} or nil}, colours = {G.C.RED}, silent = true,scale = 0.4,pop_in_rate = 10, pop_delay = 4})}}
-            }},
-            {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.1}, nodes={
-              tally_sprite({x=1,y=0},{{string = ''..ace_tally, colour = flip_col},{string =''..mod_ace_tally, colour = G.C.BLUE}}, {localize('k_aces')}),--Aces
-              tally_sprite({x=2,y=0},{{string = ''..face_tally, colour = flip_col},{string =''..mod_face_tally, colour = G.C.BLUE}}, {localize('k_face_cards')}),--Face
-              tally_sprite({x=3,y=0},{{string = ''..num_tally, colour = flip_col},{string =''..mod_num_tally, colour = G.C.BLUE}}, {localize('k_numbered_cards')}),--Numbers
-            }},
-            {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.1}, nodes={
-              tally_sprite({x=3,y=1}, {{string = ''..suit_tallies['Spades'], colour = flip_col},{string =''..mod_suit_tallies['Spades'], colour = G.C.BLUE}}, {localize('Spades', 'suits_plural')}),
-              tally_sprite({x=0,y=1}, {{string = ''..suit_tallies['Hearts'], colour = flip_col},{string =''..mod_suit_tallies['Hearts'], colour = G.C.BLUE}}, {localize('Hearts', 'suits_plural')}),
-            }},
-            {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.1}, nodes={
-              tally_sprite({x=2,y=1}, {{string = ''..suit_tallies['Clubs'], colour = flip_col},{string =''..mod_suit_tallies['Clubs'], colour = G.C.BLUE}}, {localize('Clubs', 'suits_plural')}),
-              tally_sprite({x=1,y=1}, {{string = ''..suit_tallies['Diamonds'], colour = flip_col},{string =''..mod_suit_tallies['Diamonds'], colour = G.C.BLUE}}, {localize('Diamonds', 'suits_plural')}),
-            }},
-          }}
+          {n=G.UIT.C, config={align = "cm"}, nodes=rank_cols},
+          {n=G.UIT.B, config={w = 0.1, h = 0.1}},
         }},
-        {n=G.UIT.C, config={align = "cm"}, nodes=rank_cols},
-        {n=G.UIT.B, config={w = 0.1, h = 0.1}},
+        {n=G.UIT.B, config={w = 0.2, h = 0.1}},
+        {n=G.UIT.C, config={align = "cm", padding = 0.1, r = 0.1, colour = G.C.BLACK, emboss = 0.05}, nodes=deck_tables}
       }},
-      {n=G.UIT.B, config={w = 0.2, h = 0.1}},
-      {n=G.UIT.C, config={align = "cm", padding = 0.1, r = 0.1, colour = G.C.BLACK, emboss = 0.05}, nodes=deck_tables}
-    }},
-    {n=G.UIT.R, config={align = "cm", minh = 0.8, padding = 0.05}, nodes={
-      modded and {n=G.UIT.R, config={align = "cm"}, nodes={
-        {n=G.UIT.C, config={padding = 0.3, r = 0.1, colour = mix_colours(G.C.BLUE, G.C.WHITE,0.7)}, nodes = {}},
-        {n=G.UIT.T, config={text =' '..localize('ph_deck_preview_effective'),colour = G.C.WHITE, scale =0.3}},
-      }} or nil,
-      wheel_flipped > 0 and {n=G.UIT.R, config={align = "cm"}, nodes={
-        {n=G.UIT.C, config={padding = 0.3, r = 0.1, colour = flip_col}, nodes = {}},
-        {n=G.UIT.T, config={text =' '..(wheel_flipped > 1 and
-          localize{type = 'variable', key = 'deck_preview_wheel_plural', vars = {wheel_flipped}} or
-          localize{type = 'variable', key = 'deck_preview_wheel_singular', vars = {wheel_flipped}}),colour = G.C.WHITE, scale =0.3}},
-      }} or nil,
+      {n=G.UIT.R, config={align = "cm", minh = 0.8, padding = 0.05}, nodes={
+        modded and {n=G.UIT.R, config={align = "cm"}, nodes={
+          {n=G.UIT.C, config={padding = 0.3, r = 0.1, colour = mix_colours(G.C.BLUE, G.C.WHITE,0.7)}, nodes = {}},
+          {n=G.UIT.T, config={text =' '..localize('ph_deck_preview_effective'),colour = G.C.WHITE, scale =0.3}},
+        }} or nil,
+        wheel_flipped > 0 and {n=G.UIT.R, config={align = "cm"}, nodes={
+          {n=G.UIT.C, config={padding = 0.3, r = 0.1, colour = flip_col}, nodes = {}},
+          {n=G.UIT.T, config={text =' '..(wheel_flipped > 1 and
+            localize{type = 'variable', key = 'deck_preview_wheel_plural', vars = {wheel_flipped}} or
+            localize{type = 'variable', key = 'deck_preview_wheel_singular', vars = {wheel_flipped}}),colour = G.C.WHITE, scale =0.3}},
+        }} or nil,
+      }}
     }}
-  }}
-  return t
-end
+    return t
+  end
 end
 
 function tally_sprite(pos, value, tooltip)
@@ -6439,65 +6439,76 @@ function create_UIBox_main_menu_buttons()
 
   local quit_func = 'quit'
 
-  local t = {
-    n=G.UIT.ROOT, config = {align = "cm",colour = G.C.CLEAR}, nodes={ 
-      {n=G.UIT.C, config={align = "bm"}, nodes={      
-        {n=G.UIT.R, config={align = "cm", padding = 0.2, r = 0.1, emboss = 0.1, colour = G.C.L_BLACK, mid = true}, nodes={
-          UIBox_button{id = 'main_menu_play', button = not G.SETTINGS.tutorial_complete and "start_run" or "setup_run", colour = G.C.BLUE, minw = 3.65, minh = 1.55, label = {localize('b_play_cap')}, scale = text_scale*2, col = true},
-          {n=G.UIT.C, config={align = "cm"}, nodes={
-            UIBox_button{button = 'options', colour = G.C.ORANGE, minw = 2.65, minh = 1.35, label = {localize('b_options_cap')}, scale = text_scale * 1.2, col = true},
-            G.F_QUIT_BUTTON and {n=G.UIT.C, config={align = "cm", minw = 0.2}, nodes={}} or nil,
-            G.F_QUIT_BUTTON and UIBox_button{button = quit_func, colour = G.C.RED, minw = 2.65, minh = 1.35, label = {localize('b_quit_cap')}, scale = text_scale * 1.2, col = true} or nil,
-          }},
-          UIBox_button{id = 'collection_button', button = "your_collection", colour = G.C.PALE_GREEN, minw = 3.65, minh = 1.55, label = {localize('b_collection_cap')}, scale = text_scale*1.5, col = true},
-        }},
-      }},
-      {n=G.UIT.C, config={align = "br", minw = 3.2, padding = 0.1}, nodes={
-        G.F_DISCORD and {n=G.UIT.R, config = {align = "cm", padding = 0.2}, nodes={
-          {n=G.UIT.C, config={align = "cm", padding = 0.1, r = 0.1, hover = true, colour = mix_colours(G.C.BLUE, G.C.GREY, 0.4), button = 'go_to_discord', shadow = true}, nodes={
-            {n=G.UIT.O, config={object = discord}},
-          }},
-          {n=G.UIT.C, config={align = "cm", padding = 0.1, r = 0.1, hover = true, colour = G.C.BLACK, button = 'go_to_twitter', shadow = true}, nodes={
-            {n=G.UIT.O, config={object = twitter}},
-          }}
-        }} or nil,
-        not G.F_ENGLISH_ONLY and {n=G.UIT.R, config = {align = "cm", padding = 0.2, r = 0.1, emboss = 0.1, colour = G.C.L_BLACK}, nodes={
-          {n=G.UIT.R, config={align = "cm", padding = 0.15, minw = 1, r = 0.1, hover = true, colour = mix_colours(G.C.WHITE, G.C.GREY, 0.2), button = 'language_selection', shadow = true}, nodes={
-            {n=G.UIT.O, config={object = language}},
-            {n=G.UIT.T, config={text = G.LANG.label, scale = 0.4, colour = G.C.UI.TEXT_LIGHT, shadow = true}}
-          }}
-        }} or nil,
-      }},
-    }}
   -- PORTRAIT MODE: Vertical button layout
   if G.F_PORTRAIT then
     local t = {
-      n=G.UIT.ROOT, config = {align = "bm", colour = G.C.CLEAR}, nodes={ 
-        {n=G.UIT.C, config={align = "cm"}, nodes={      
-          {n=G.UIT.R, config={align = "cm", padding = 0.1, r = 0.1, emboss = 0.1, colour = G.C.L_BLACK}, nodes={
-            -- Row 1: Profile + Play
-            {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={
-              not G.F_ENGLISH_ONLY and {n=G.UIT.C, config={align = "cm", padding = 0.1, minw = 0.8, r = 0.1, hover = true, colour = mix_colours(G.C.WHITE, G.C.GREY, 0.2), button = 'language_selection', shadow = true}, nodes={
-                {n=G.UIT.O, config={object = language}},
-              }} or nil,
-              UIBox_button{id = 'main_menu_play', button = not G.SETTINGS.tutorial_complete and "start_run" or "setup_run", colour = G.C.BLUE, minw = 2, minh = 1, label = {localize('b_play_cap')}, scale = text_scale*1.5, col = true},
+      n=G.UIT.ROOT, config = {align = "bm", colour = G.C.CLEAR}, nodes={
+        {n=G.UIT.C, config={align = "bm"}, nodes={
+          {n=G.UIT.R, config={align = "cm", padding = 0.15, r = 2, emboss = 0.1, colour = G.C.L_BLACK}, nodes={
+            -- Row 1: Languages + Play
+            {n=G.UIT.R, config={align = "cm", minw = 4, minh = 0.8, padding = 0.15}, nodes={
+              UIBox_button{id = 'main_menu_play', button = not G.SETTINGS.tutorial_complete and "start_run" or "setup_run", colour = G.C.BLUE, minw = 5.55, minh = 2, emboss = 1, label = {localize('b_play_cap')}, scale = text_scale*3, col = true},
             }},
             -- Row 2: Options + Quit
-            {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={
-              UIBox_button{button = 'options', colour = G.C.ORANGE, minw = 1.5, minh = 0.8, label = {localize('b_options_cap')}, scale = text_scale, col = true},
-              G.F_QUIT_BUTTON and UIBox_button{button = quit_func, colour = G.C.RED, minw = 1.5, minh = 0.8, label = {localize('b_quit_cap')}, scale = text_scale, col = true} or nil,
+            {n=G.UIT.R, config={align = "cm", padding = 0.25}, nodes={
+              UIBox_button{button = 'options', colour = G.C.ORANGE, minw = 2.55, minh = 1.25, label = {localize('b_options_cap')}, scale = text_scale*1.1, col = true},
+              G.F_QUIT_BUTTON and UIBox_button{button = quit_func, colour = G.C.RED, minw = 2.55, minh = 1.25, label = {localize('b_quit_cap')}, scale = text_scale*1.1, col = true} or nil,
             }},
             -- Row 3: Collection
-            {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={
-              UIBox_button{id = 'collection_button', button = "your_collection", colour = G.C.PALE_GREEN, minw = 2, minh = 0.8, label = {localize('b_collection_cap')}, scale = text_scale, col = true},
+            {n=G.UIT.R, config={align = "cm", padding = 0.15}, nodes={
+              UIBox_button{id = 'collection_button', button = "your_collection", colour = G.C.PALE_GREEN, minw = 3.65, minh = 1.55, label = {localize('b_collection_cap')}, scale = text_scale*1.5, col = true},
+            }},
+          }},
+        }},
+        {n=G.UIT.C, config={align = "bm"}, nodes={
+          {n=G.UIT.B, config={w = 0.7, h = 0.25}},
+        }},
+        {n=G.UIT.C, config={align = "bm"}, nodes={
+          {n=G.UIT.R, config={align = "cm", padding = 0.15, r = 2, emboss = 0.1, colour = G.C.L_BLACK}, nodes={
+            -- Row 4: Languages
+            {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
+              not G.F_ENGLISH_ONLY and {n=G.UIT.C, config={align = "cm", padding = 0.1, minw = 0.8, r = 0.1, hover = true, colour = mix_colours(G.C.WHITE, G.C.GREY, 0.15), button = 'language_selection', shadow = true}, nodes={
+                {n=G.UIT.O, config={object = language}},
+                -- {n=G.UIT.T, config={text = G.LANG.label, scale = 0.4, colour = G.C.UI.TEXT_LIGHT, shadow = true}}
+              }} or nil,
             }},
           }},
         }},
       }}
     return t
+  else
+    local t = {
+      n=G.UIT.ROOT, config = {align = "cm",colour = G.C.CLEAR}, nodes={ 
+        {n=G.UIT.C, config={align = "bm"}, nodes={      
+          {n=G.UIT.R, config={align = "cm", padding = 0.2, r = 0.1, emboss = 0.1, colour = G.C.L_BLACK, mid = true}, nodes={
+            UIBox_button{id = 'main_menu_play', button = not G.SETTINGS.tutorial_complete and "start_run" or "setup_run", colour = G.C.BLUE, minw = 3.65, minh = 1.55, label = {localize('b_play_cap')}, scale = text_scale*2, col = true},
+            {n=G.UIT.C, config={align = "cm"}, nodes={
+              UIBox_button{button = 'options', colour = G.C.ORANGE, minw = 2.65, minh = 1.35, label = {localize('b_options_cap')}, scale = text_scale * 1.2, col = true},
+              G.F_QUIT_BUTTON and {n=G.UIT.C, config={align = "cm", minw = 0.2}, nodes={}} or nil,
+              G.F_QUIT_BUTTON and UIBox_button{button = quit_func, colour = G.C.RED, minw = 2.65, minh = 1.35, label = {localize('b_quit_cap')}, scale = text_scale * 1.2, col = true} or nil,
+            }},
+            UIBox_button{id = 'collection_button', button = "your_collection", colour = G.C.PALE_GREEN, minw = 3.65, minh = 1.55, label = {localize('b_collection_cap')}, scale = text_scale*1.5, col = true},
+          }},
+        }},
+        {n=G.UIT.C, config={align = "br", minw = 3.2, padding = 0.1}, nodes={
+          G.F_DISCORD and {n=G.UIT.R, config = {align = "cm", padding = 0.2}, nodes={
+            {n=G.UIT.C, config={align = "cm", padding = 0.1, r = 0.1, hover = true, colour = mix_colours(G.C.BLUE, G.C.GREY, 0.4), button = 'go_to_discord', shadow = true}, nodes={
+              {n=G.UIT.O, config={object = discord}},
+            }},
+            {n=G.UIT.C, config={align = "cm", padding = 0.1, r = 0.1, hover = true, colour = G.C.BLACK, button = 'go_to_twitter', shadow = true}, nodes={
+              {n=G.UIT.O, config={object = twitter}},
+            }}
+          }} or nil,
+          not G.F_ENGLISH_ONLY and {n=G.UIT.R, config = {align = "cm", padding = 0.2, r = 0.1, emboss = 0.1, colour = G.C.L_BLACK}, nodes={
+            {n=G.UIT.R, config={align = "cm", padding = 0.15, minw = 1, r = 0.1, hover = true, colour = mix_colours(G.C.WHITE, G.C.GREY, 0.2), button = 'language_selection', shadow = true}, nodes={
+              {n=G.UIT.O, config={object = language}},
+              {n=G.UIT.T, config={text = G.LANG.label, scale = 0.4, colour = G.C.UI.TEXT_LIGHT, shadow = true}}
+            }}
+          }} or nil,
+        }},
+      }}
+    return t
   end
-
-  return t
 end
 
 function create_UIBox_main_menu_competittion_name()

--- a/src/functions/UI_definitions.lua
+++ b/src/functions/UI_definitions.lua
@@ -2165,11 +2165,51 @@ function create_tabs(args)
     tab_buttons[#tab_buttons+1] = UIBox_button({id = 'tab_but_'..(v.label or ''), ref_table = v, button = 'change_tab', label = {v.label}, minh = 0.8*args.scale, minw = 2.5*args.scale, col = true, choice = true, scale = args.text_scale, chosen = v.chosen, func = v.func, focus_args = {type = 'none'}})
   end
 
+  -- Multi-line portrait layout
+  local tabs_container_nodes = tab_buttons
+
+  if G.F_PORTRAIT then
+    local total_tabs = #tab_buttons
+
+    -- 1 to 4 tabs → usual behavior
+    if total_tabs > 4 then
+      
+      local per_row
+      
+      if total_tabs <= 6 then
+        per_row = 3     -- 5 → 3+2 | 6 → 3+3
+      else
+        per_row = 4     -- 7 → 4+3 | 8 → 4+4 | 9+ → 4+x
+      end
+
+      local total_rows = math.ceil(total_tabs / per_row)
+      tabs_container_nodes = {}
+      local index = 1
+
+      for r = 1, total_rows do
+        local row_nodes = {}
+
+        for c = 1, per_row do
+          if tab_buttons[index] then
+            row_nodes[#row_nodes+1] = tab_buttons[index]
+            index = index + 1
+          end
+        end
+
+        tabs_container_nodes[#tabs_container_nodes+1] = {
+          n = G.UIT.R,
+          config = {align = "cm", padding = 0.05},
+          nodes = row_nodes
+        }
+      end
+    end
+  end
+
   local t = 
   {n=G.UIT.R, config={padding = 0.0, align = "cm", colour = G.C.CLEAR}, nodes={
     {n=G.UIT.R, config={align = "cm", colour = G.C.CLEAR}, nodes = {
       (#args.tabs > 1 and not args.no_shoulders) and {n=G.UIT.C, config={minw = 0.7,align = "cm", colour = G.C.CLEAR,func = 'set_button_pip', focus_args = {button = 'leftshoulder', type = 'none', orientation = 'cm', scale = 0.7, offset = {x = -0.1, y = 0}}}, nodes = {}} or nil,
-      {n=G.UIT.C, config={id = args.no_shoulders and 'no_shoulders' or 'tab_shoulders', ref_table = args, align = "cm", padding = 0.15, group = 1, collideable = true, focus_args = #args.tabs > 1 and {type = 'tab', nav = 'wide',snap_to = args.snap_to_nav, no_loop = args.no_loop} or nil}, nodes=tab_buttons},
+      {n=G.UIT.C, config={id = args.no_shoulders and 'no_shoulders' or 'tab_shoulders', ref_table = args, align = "cm", padding = 0.15, group = 1, collideable = true, focus_args = #args.tabs > 1 and {type = 'tab', nav = 'wide',snap_to = args.snap_to_nav, no_loop = args.no_loop} or nil}, nodes=tabs_container_nodes},
       (#args.tabs > 1 and not args.no_shoulders) and {n=G.UIT.C, config={minw = 0.7,align = "cm", colour = G.C.CLEAR,func = 'set_button_pip', focus_args = {button = 'rightshoulder', type = 'none', orientation = 'cm', scale = 0.7, offset = {x = 0.1, y = 0}}}, nodes = {}} or nil,
     }},
     {n=G.UIT.R, config={align = args.tab_alignment, padding = args.padding or 0.1, no_fill = true, minh = args.tab_h, minw = args.tab_w}, nodes={
@@ -2529,22 +2569,27 @@ function create_UIBox_usage(args)
 
   table.sort(used_cards, function (a, b) return a.count > b.count end )
 
+  local scale_histo = 1
+  if G.F_PORTRAIT then
+    scale_histo = 0.7
+  end
+
   local histograms = {}
 
   for i = 1, 10 do
     local v = used_cards[i]
     if v then 
-      local card = Card(0,0, 0.7*G.CARD_W, 0.7*G.CARD_H, nil, G.P_CENTERS[v.key])
+      local card = Card(0,0, 0.7*G.CARD_W*scale_histo, 0.7*G.CARD_H*scale_histo, nil, G.P_CENTERS[v.key])
       card.ambient_tilt = 0.8
       local cardarea = CardArea(
         G.ROOM.T.x + 0.2*G.ROOM.T.w/2,G.ROOM.T.h,
-        G.CARD_W*0.7,
-        G.CARD_H*0.7, 
+        G.CARD_W*0.7*scale_histo,
+        G.CARD_H*0.7*scale_histo, 
         {card_limit = 2, type = 'title', highlight_limit = 0})
       cardarea:emplace(card)
 
       histograms[#histograms +1] = 
-      {n=G.UIT.C, config={align = "bm",minh = 6.2,  colour = G.C.UI.TRANSPARENT_DARK, r = 0.1}, nodes={
+      {n=G.UIT.C, config={align = "bm",minh = 6.2*scale_histo,  colour = G.C.UI.TRANSPARENT_DARK, r = 0.1}, nodes={
         
         {n=G.UIT.R, config={align = "bm"}, nodes={
           {n=G.UIT.R, config={align = "cm", minh = 0.7*G.CARD_H+0.1} , nodes={
@@ -2554,21 +2599,21 @@ function create_UIBox_usage(args)
             {n=G.UIT.T, config={text = v.count, scale = 0.35, colour = mix_colours(G.C.FILTER, G.C.WHITE, 0.8), shadow = true}}
           }},
           {n=G.UIT.R, config={align = "cm"}, nodes={
-            {n=G.UIT.R, config={align = "cm", minh = v.count/max_amt*3.6, minw = 0.8, colour = G.C.SECONDARY_SET[G.P_CENTERS[v.key].set] or G.C.RED, res = 0.15, r = 0.001}, nodes={}},
+            {n=G.UIT.R, config={align = "cm", minh = (v.count/max_amt*3.6)*scale_histo, minw = 0.8*scale_histo, colour = G.C.SECONDARY_SET[G.P_CENTERS[v.key].set] or G.C.RED, res = 0.15, r = 0.001}, nodes={}},
           }},
         }},
       }}
     else
       histograms[#histograms +1] = 
-      {n=G.UIT.C, config={align = "bm",minh = 6.2,  colour = G.C.UI.TRANSPARENT_DARK, r = 0.1}, nodes={
+      {n=G.UIT.C, config={align = "bm",minh = 6.2*scale_histo,  colour = G.C.UI.TRANSPARENT_DARK, r = 0.1}, nodes={
         {n=G.UIT.R, config={align = "bm"}, nodes={
-          {n=G.UIT.R, config={align = "cm", minh = 0.7*G.CARD_H+0.1, minw = 0.7*G.CARD_W} , nodes={
+          {n=G.UIT.R, config={align = "cm", minh = 0.7*G.CARD_H*scale_histo+0.1, minw = 0.7*G.CARD_W*scale_histo} , nodes={
           }},
           {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
             {n=G.UIT.T, config={text = '-', scale = 0.35, colour = mix_colours(G.C.FILTER, G.C.WHITE, 0.8), shadow = true}}
           }},
           {n=G.UIT.R, config={align = "cm"}, nodes={
-            {n=G.UIT.R, config={align = "cm", minh = 0.2, minw = 0.8, colour = G.C.UI.TRANSPARENT_LIGHT, res = 0.15, r = 0.001}, nodes={}},
+            {n=G.UIT.R, config={align = "cm", minh = 0.2*scale_histo, minw = 0.8*scale_histo, colour = G.C.UI.TRANSPARENT_LIGHT, res = 0.15, r = 0.001}, nodes={}},
           }},
         }},
       }}
@@ -2683,14 +2728,20 @@ function create_UIBox_high_scores()
   }
   G.focused_profile = G.SETTINGS.profile
   local cheevs = {}
+
+  if G.F_PORTRAIT then
+    display = G.UIT.R
+  else
+    display = G.UIT.C
+  end
   
   local t = create_UIBox_generic_options({ back_func = 'options', snap_back = true, contents = {
-    {n=G.UIT.C, config={align = "cm", minw = 3, padding = 0.2, r = 0.1, colour = G.C.CLEAR}, nodes={
+    {n=display, config={align = "cm", minw = 3, padding = 0.2, r = 0.1, colour = G.C.CLEAR}, nodes={
       {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes=
         scores
       },
     }},
-    {n=G.UIT.C, config={align = "cm", padding = 0.1, r = 0.1, colour = G.C.CLEAR}, nodes={
+    {n=display, config={align = "cm", padding = 0.1, r = 0.1, colour = G.C.CLEAR}, nodes={
       create_progress_box(),
       UIBox_button({button = 'usage', label = {localize('k_card_stats')}, minw = 7.5, minh =1, focus_args = {nav = 'wide'}}),
     }},
@@ -3806,14 +3857,16 @@ end
 
 function create_UIBox_your_collection_tarots()
   local deck_tables = {}
-
   G.your_collection = {}
-  for j = 1, 2 do
+
+  local row_sizes = G.F_PORTRAIT and {3, 4, 4} or {5, 6}
+  
+  for j = 1, #row_sizes do
     G.your_collection[j] = CardArea(
       G.ROOM.T.x + 0.2*G.ROOM.T.w/2,G.ROOM.T.h,
-      (4.25+j)*G.CARD_W,
+      (row_sizes[j] + 0.25)*G.CARD_W,
       1*G.CARD_H, 
-      {card_limit = 4 + j, type = 'title', highlight_limit = 0, collection = true})
+      {card_limit = row_sizes[j], type = 'title', highlight_limit = 0, collection = true})
     table.insert(deck_tables, 
     {n=G.UIT.R, config={align = "cm", padding = 0, no_fill = true}, nodes={
       {n=G.UIT.O, config={object = G.your_collection[j]}}
@@ -3826,12 +3879,19 @@ function create_UIBox_your_collection_tarots()
     table.insert(tarot_options, localize('k_page')..' '..tostring(i)..'/'..tostring(math.floor(#G.P_CENTER_POOLS.Tarot/11)))
   end
 
-    for j = 1, #G.your_collection do
-      for i = 1, 4+j do
-      local center = G.P_CENTER_POOLS["Tarot"][i+(j-1)*(5)]
-      local card = Card(G.your_collection[j].T.x + G.your_collection[j].T.w/2, G.your_collection[j].T.y, G.CARD_W, G.CARD_H, nil, center)
-      card:start_materialize(nil, i>1 or j>1)
-      G.your_collection[j]:emplace(card)
+  local card_index = 1
+
+  for j = 1, #G.your_collection do
+    for i = 1, row_sizes[j] do
+      local center = G.P_CENTER_POOLS["Tarot"][card_index]
+      
+      if center then 
+        local card = Card(G.your_collection[j].T.x + G.your_collection[j].T.w/2, G.your_collection[j].T.y, G.CARD_W, G.CARD_H, nil, center)
+        card:start_materialize(nil, i>1 or j>1)
+        G.your_collection[j]:emplace(card)
+      end
+      
+      card_index = card_index + 1
     end
   end
 
@@ -3891,13 +3951,21 @@ end
 function create_UIBox_your_collection_planets()
   local deck_tables = {}
 
+  local nb_rows = 2
+  local nb_cols = 6
+
+  if G.F_PORTRAIT then
+    nb_rows = 3
+    nb_cols = 4
+  end
+
   G.your_collection = {}
-  for j = 1, 2 do
+  for j = 1, nb_rows do
     G.your_collection[j] = CardArea(
       G.ROOM.T.x + 0.2*G.ROOM.T.w/2,G.ROOM.T.h,
-      (6.25)*G.CARD_W,
+      (nb_cols+0.25)*G.CARD_W,
       1*G.CARD_H, 
-      {card_limit = 6, type = 'title', highlight_limit = 0, collection = true})
+      {card_limit = nb_cols, type = 'title', highlight_limit = 0, collection = true})
     table.insert(deck_tables, 
     {n=G.UIT.R, config={align = "cm", padding = 0, no_fill = true}, nodes={
       {n=G.UIT.O, config={object = G.your_collection[j]}}
@@ -3906,8 +3974,8 @@ function create_UIBox_your_collection_planets()
   end
 
     for j = 1, #G.your_collection do
-      for i = 1, 6 do
-      local center = G.P_CENTER_POOLS["Planet"][i+(j-1)*(6)]
+      for i = 1, nb_cols do
+      local center = G.P_CENTER_POOLS["Planet"][i+(j-1)*(nb_cols)]
       local card = Card(G.your_collection[j].T.x + G.your_collection[j].T.w/2, G.your_collection[j].T.y, G.CARD_W, G.CARD_H, nil, center)
       card:start_materialize(nil, i>1 or j>1)
       G.your_collection[j]:emplace(card)
@@ -5731,6 +5799,11 @@ end
 
 function G.UIDEF.challenge_list(from_game_over)
   G.CHALLENGE_PAGE_SIZE = 10
+
+  if G.F_PORTRAIT then
+    G.CHALLENGE_PAGE_SIZE = 5
+  end
+
   local challenge_pages = {}
   for i = 1, math.ceil(#G.CHALLENGES/G.CHALLENGE_PAGE_SIZE) do
     table.insert(challenge_pages, localize('k_page')..' '..tostring(i)..'/'..tostring(math.ceil(#G.CHALLENGES/G.CHALLENGE_PAGE_SIZE)))
@@ -5745,25 +5818,45 @@ function G.UIDEF.challenge_list(from_game_over)
       _ch_comp = _ch_comp + 1
     end
   end
+  if G.F_PORTRAIT then
+    local t = create_UIBox_generic_options({ back_id = from_game_over and 'from_game_over' or nil, back_func = 'setup_run', back_id = 'challenge_list', contents = {
+      {n=G.UIT.R, config={align = "cm", minh = 9, minw = 11.5}, nodes={
+        {n=G.UIT.O, config={id = 'challenge_area', object = Moveable()}},
+      }},
+      {n=G.UIT.R, config={align = "cm", padding = 0.0}, nodes={
+        {n=G.UIT.R, config={align = "cm", padding = 0.1, minh = 3.5, minw = 4.2}, nodes={
+          {n=G.UIT.O, config={id = 'challenge_list', object = Moveable()}},
+        }},
+        {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
+          create_option_cycle({id = 'challenge_page',scale = 0.9, h = 0.3, w = 3.5, options = challenge_pages, cycle_shoulders = true, opt_callback = 'change_challenge_list_page', current_option = 1, colour = G.C.RED, no_pips = true, focus_args = {snap_to = true}})
+        }},
+        {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
+          {n=G.UIT.T, config={text = localize{type = 'variable', key = 'challenges_completed', vars = {_ch_comp, _ch_tot}}, scale = 0.4, colour = G.C.WHITE}},
+        }},
 
-  local t = create_UIBox_generic_options({ back_id = from_game_over and 'from_game_over' or nil, back_func = 'setup_run', back_id = 'challenge_list', contents = {
-    {n=G.UIT.C, config={align = "cm", padding = 0.0}, nodes={
-      {n=G.UIT.R, config={align = "cm", padding = 0.1, minh = 7, minw = 4.2}, nodes={
-        {n=G.UIT.O, config={id = 'challenge_list', object = Moveable()}},
       }},
-      {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
-        create_option_cycle({id = 'challenge_page',scale = 0.9, h = 0.3, w = 3.5, options = challenge_pages, cycle_shoulders = true, opt_callback = 'change_challenge_list_page', current_option = 1, colour = G.C.RED, no_pips = true, focus_args = {snap_to = true}})
-      }},
-      {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
-        {n=G.UIT.T, config={text = localize{type = 'variable', key = 'challenges_completed', vars = {_ch_comp, _ch_tot}}, scale = 0.4, colour = G.C.WHITE}},
-      }},
+    }})
+    return t
+  else
+    local t = create_UIBox_generic_options({ back_id = from_game_over and 'from_game_over' or nil, back_func = 'setup_run', back_id = 'challenge_list', contents = {
+      {n=G.UIT.C, config={align = "cm", padding = 0.0}, nodes={
+        {n=G.UIT.R, config={align = "cm", padding = 0.1, minh = 7, minw = 4.2}, nodes={
+          {n=G.UIT.O, config={id = 'challenge_list', object = Moveable()}},
+        }},
+        {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
+          create_option_cycle({id = 'challenge_page',scale = 0.9, h = 0.3, w = 3.5, options = challenge_pages, cycle_shoulders = true, opt_callback = 'change_challenge_list_page', current_option = 1, colour = G.C.RED, no_pips = true, focus_args = {snap_to = true}})
+        }},
+        {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
+          {n=G.UIT.T, config={text = localize{type = 'variable', key = 'challenges_completed', vars = {_ch_comp, _ch_tot}}, scale = 0.4, colour = G.C.WHITE}},
+        }},
 
-    }},
-    {n=G.UIT.C, config={align = "cm", minh = 9, minw = 11.5}, nodes={
-      {n=G.UIT.O, config={id = 'challenge_area', object = Moveable()}},
-    }},
-  }})
-  return t
+      }},
+      {n=G.UIT.C, config={align = "cm", minh = 9, minw = 11.5}, nodes={
+        {n=G.UIT.O, config={id = 'challenge_area', object = Moveable()}},
+      }},
+    }})
+    return t
+  end
 end
 
 function G.UIDEF.challenge_list_page(_page)

--- a/src/functions/UI_definitions.lua
+++ b/src/functions/UI_definitions.lua
@@ -3379,6 +3379,11 @@ function G.UIDEF.current_stake()
 end
 
 function G.UIDEF.view_deck(unplayed_only)
+  local SCALE =  1
+  if G.F_PORTRAIT then
+    SCALE = 0.8
+  end
+
   local deck_tables = {}
   remove_nils(G.playing_cards)
   G.VIEWING_DECK = true
@@ -3397,9 +3402,9 @@ function G.UIDEF.view_deck(unplayed_only)
     if SUITS[suit_map[j]][1] then
       local view_deck = CardArea(
         G.ROOM.T.x + 0.2*G.ROOM.T.w/2,G.ROOM.T.h,
-        6.5*G.CARD_W,
-        0.6*G.CARD_H,
-        {card_limit = #SUITS[suit_map[j]], type = 'title', view_deck = true, highlight_limit = 0, card_w = G.CARD_W*0.7, draw_layers = {'card'}})
+        6.5*G.CARD_W*SCALE,
+        0.6*G.CARD_H*SCALE,
+        {card_limit = #SUITS[suit_map[j]], type = 'title', view_deck = true, highlight_limit = 0, card_w = G.CARD_W*0.7*SCALE, draw_layers = {'card'}})
       table.insert(deck_tables, 
       {n=G.UIT.R, config={align = "cm", padding = 0}, nodes={
         {n=G.UIT.O, config={object = view_deck}}
@@ -3490,7 +3495,83 @@ function G.UIDEF.view_deck(unplayed_only)
     }}
   end
 
+  local rank_rows = {n = G.UIT.R, config = {align = "cm", padding = 0.05}, nodes = {}}
+  for i = 13, 1, -1 do
+    local mod_delta2 = mod_rank_tallies[i] ~= rank_tallies[i]
+    rank_rows.nodes[#rank_rows.nodes+1] = {n=G.UIT.C, config={align = "cm", padding = 0.07}, nodes={
+      -- Rank row (A, K, Q, etc.)
+      {n=G.UIT.R, config={align = "cm", r = 0.1, padding = 0.04, emboss = 0.04, minw = 0.5, colour = G.C.L_BLACK}, nodes={
+        {n=G.UIT.T, config={text = rank_name_mapping[i],colour = G.C.JOKER_GREY, scale = 0.35, shadow = true}},
+      }},
+      -- Tally row
+      {n=G.UIT.R, config={align = "cm", minw = 0.4}, nodes={
+        mod_delta2 and {n=G.UIT.O, config={object = DynaText({string = {{string = ''..rank_tallies[i], colour = flip_col},{string =''..mod_rank_tallies[i], colour = G.C.BLUE}}, colours = {G.C.RED}, scale = 0.4, y_offset = -2, silent = true, shadow = true, pop_in_rate = 10, pop_delay = 4})}} or
+        {n=G.UIT.T, config={text = rank_tallies[i] or 'NIL',colour = flip_col, scale = 0.45, shadow = true}}
+      }}
+    }}
+  end
 
+  if G.F_PORTRAIT then
+    local t = 
+    {n=G.UIT.ROOT, config={align = "cm", colour = G.C.CLEAR}, nodes={
+      {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={}},
+      {n=G.UIT.R, config={align = "cm"}, nodes={
+        {n=G.UIT.R, config={align = "cm", minw = 1.5, minh = 2, r = 0.1, colour = G.C.BLACK, emboss = 0.05}, nodes={
+          {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
+            {n=G.UIT.C, config={align = "cm", r = 0.1, colour = G.C.L_BLACK, emboss = 0.05, padding = 0.15}, nodes={
+              {n=G.UIT.R, config={align = "cm"}, nodes={
+                {n=G.UIT.O, config={object = DynaText({string = G.GAME.selected_back.loc_name, colours = {G.C.WHITE}, bump = true, rotate = true, shadow = true, scale = 0.6 - string.len(G.GAME.selected_back.loc_name)*0.01})}},
+              }},
+              {n=G.UIT.R, config={align = "cm", r = 0.1, padding = 0.1, minw = 2.5, minh = 1.3, colour = G.C.WHITE, emboss = 0.05}, nodes={
+                {n=G.UIT.O, config={object = UIBox{
+                  definition = G.GAME.selected_back:generate_UI(nil,0.7, 0.5, G.GAME.challenge),
+                  config = {offset = {x=0,y=0}}
+                }}}
+              }}
+            }},
+            {n=G.UIT.B, config={w = 0.25, h = 0.25}},
+            {n=G.UIT.C, config={align = "cm", r = 0.1, outline_colour = G.C.L_BLACK, line_emboss = 0.05, outline = 1.5}, nodes={
+              {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.07}, nodes={
+                  {n=G.UIT.O, config={object = DynaText({string = {{string = localize('k_base_cards'), colour = G.C.RED}, modded and {string = localize('k_effective'), colour = G.C.BLUE} or nil}, colours = {G.C.RED}, silent = true,scale = 0.4,pop_in_rate = 10, pop_delay = 4})}}
+              }},
+              {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.1}, nodes={
+                tally_sprite({x=1,y=0},{{string = ''..ace_tally, colour = flip_col},{string =''..mod_ace_tally, colour = G.C.BLUE}}, {localize('k_aces')}),--Aces
+                tally_sprite({x=2,y=0},{{string = ''..face_tally, colour = flip_col},{string =''..mod_face_tally, colour = G.C.BLUE}}, {localize('k_face_cards')}),--Face
+                tally_sprite({x=3,y=0},{{string = ''..num_tally, colour = flip_col},{string =''..mod_num_tally, colour = G.C.BLUE}}, {localize('k_numbered_cards')}),--Numbers
+              }},
+              {n=G.UIT.R, config={align = "cm", minh = 0.05, padding = 0.1}, nodes={
+                tally_sprite({x=3,y=1}, {{string = ''..suit_tallies['Spades'], colour = flip_col},{string =''..mod_suit_tallies['Spades'], colour = G.C.BLUE}}, {localize('Spades', 'suits_plural')}),
+                tally_sprite({x=0,y=1}, {{string = ''..suit_tallies['Hearts'], colour = flip_col},{string =''..mod_suit_tallies['Hearts'], colour = G.C.BLUE}}, {localize('Hearts', 'suits_plural')}),
+                tally_sprite({x=2,y=1}, {{string = ''..suit_tallies['Clubs'], colour = flip_col},{string =''..mod_suit_tallies['Clubs'], colour = G.C.BLUE}}, {localize('Clubs', 'suits_plural')}),
+                tally_sprite({x=1,y=1}, {{string = ''..suit_tallies['Diamonds'], colour = flip_col},{string =''..mod_suit_tallies['Diamonds'], colour = G.C.BLUE}}, {localize('Diamonds', 'suits_plural')}),
+              }},
+            }}
+          }},
+          rank_rows
+        }}
+      }},
+      {n=G.UIT.R, config={align = "cm"}, nodes={
+        {n=G.UIT.B, config={w = 0.2, h = 0.8}},
+      }},
+      {n=G.UIT.R, config={align = "cm"}, nodes={
+        {n=G.UIT.B, config={w = 0.2, h = 0.5}},
+        {n=G.UIT.C, config={align = "cm", padding = 0.1, r = 0.1, colour = G.C.BLACK, emboss = 0.05}, nodes=deck_tables}
+      }},
+      {n=G.UIT.R, config={align = "cm", minh = 0.8, padding = 0.05}, nodes={
+        modded and {n=G.UIT.R, config={align = "cm"}, nodes={
+          {n=G.UIT.C, config={padding = 0.3, r = 0.1, colour = mix_colours(G.C.BLUE, G.C.WHITE,0.7)}, nodes = {}},
+          {n=G.UIT.T, config={text =' '..localize('ph_deck_preview_effective'),colour = G.C.WHITE, scale =0.3}},
+        }} or nil,
+        wheel_flipped > 0 and {n=G.UIT.R, config={align = "cm"}, nodes={
+          {n=G.UIT.C, config={padding = 0.3, r = 0.1, colour = flip_col}, nodes = {}},
+          {n=G.UIT.T, config={text =' '..(wheel_flipped > 1 and
+            localize{type = 'variable', key = 'deck_preview_wheel_plural', vars = {wheel_flipped}} or
+            localize{type = 'variable', key = 'deck_preview_wheel_singular', vars = {wheel_flipped}}),colour = G.C.WHITE, scale =0.3}},
+        }} or nil,
+      }}
+    }}
+    return t
+  else
   local t = 
   {n=G.UIT.ROOT, config={align = "cm", colour = G.C.CLEAR}, nodes={
     {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={}},
@@ -3547,6 +3628,7 @@ function G.UIDEF.view_deck(unplayed_only)
     }}
   }}
   return t
+end
 end
 
 function tally_sprite(pos, value, tooltip)

--- a/src/functions/UI_definitions.lua
+++ b/src/functions/UI_definitions.lua
@@ -2918,6 +2918,14 @@ function create_UIBox_win()
   }}
   }}
   }}) 
+  if G.F_PORTRAIT then
+    t.nodes[1] = {n=G.UIT.C, config={align = "cm", padding = 0.1}, nodes={
+        t.nodes[1],
+        {n=G.UIT.R, config={align = "cm", padding = 0.5}, nodes={
+          {n=G.UIT.O, config={padding = 0, id = 'jimbo_spot', object = Moveable(0,0,G.CARD_W*1.1, G.CARD_H*1.1)}},
+        }},
+      }}
+  else
   t.nodes[1] = {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
       {n=G.UIT.C, config={align = "cm", padding = 2}, nodes={
         {n=G.UIT.O, config={padding = 0, id = 'jimbo_spot', object = Moveable(0,0,G.CARD_W*1.1, G.CARD_H*1.1)}},
@@ -2925,6 +2933,7 @@ function create_UIBox_win()
       {n=G.UIT.C, config={align = "cm", padding = 0.1}, nodes={t.nodes[1]}
     }}
   }
+  end
   --t.nodes[1].config.mid = true
   t.config.id = 'you_win_UI'
   return t
@@ -3002,11 +3011,14 @@ function create_UIBox_game_over()
   
   if G.F_PORTRAIT then
     stats_content = {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={
-      {n=G.UIT.C, config={align = "cm"}, nodes={
+      {n=G.UIT.C, config={align = "cm", padding = 0.1}, nodes={
         {n=G.UIT.R, config={align = "cm", padding = 0.05, colour = G.C.BLACK, emboss = 0.05, r = 0.1}, nodes={
           {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={
             create_UIBox_round_scores_row('hand'),
             create_UIBox_round_scores_row('poker_hand'),
+          }},
+          {n=G.UIT.R, config={align = "cm"}, nodes={
+            {n=G.UIT.B, config={w = 0.08, h = 0.15}}
           }},
           {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={
             create_UIBox_round_scores_row('cards_played', G.C.BLUE),
@@ -3018,39 +3030,46 @@ function create_UIBox_game_over()
           }},
           {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={
             create_UIBox_round_scores_row('new_collection', G.C.WHITE),
-            create_UIBox_round_scores_row('seed', G.C.WHITE),
           }},
+          {n=G.UIT.R, config={align = "cm"}, nodes={
+            {n=G.UIT.B, config={w = 0.08, h = 0.15}}
+          }},
+          {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
+            {n=G.UIT.C, config={align = "cm", padding = 0.1}, nodes={
           {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={
             create_UIBox_round_scores_row('furthest_ante', G.C.FILTER),
             create_UIBox_round_scores_row('furthest_round', G.C.FILTER),
           }},
           {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={
+                create_UIBox_round_scores_row('seed', G.C.WHITE),
+                UIBox_button({button = 'copy_seed', label = {localize('b_copy')}, padding = 0.05, colour = G.C.BLUE, scale = 0.3, minw = 2.3, minh = 0.4, focus_args = {nav = 'wide'}}),
+              }},
+            }},
+            {n=G.UIT.C, config={align = "cm", padding = 0.1}, nodes={
             create_UIBox_round_scores_row('defeated_by'),
           }},
-          {n=G.UIT.R, config={align = "cm", padding = 0.05}, nodes={
-            UIBox_button({button = 'copy_seed', label = {localize('b_copy')}, colour = G.C.BLUE, scale = 0.3, minw = 2.3, minh = 0.4, focus_args = {nav = 'wide'}}),
           }},
         }},
         show_lose_cta and 
-        {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
+        {n=G.UIT.R, config={align = "cm", padding = 0.25}, nodes={
           {n=G.UIT.C, config={id = 'lose_cta', align = "cm", minw = 5, padding = 0.1, r = 0.1, hover = true, colour = G.C.GREEN, button = "show_main_cta", shadow = true}, nodes={
             {n=G.UIT.R, config={align = "cm", padding = 0, no_fill = true}, nodes={
               {n=G.UIT.T, config={text = localize('b_next'), scale = 0.5, colour = G.C.UI.TEXT_LIGHT, focus_args = {nav = 'wide', snap_to = true}}}
             }}
           }}
         }} or
-        {n=G.UIT.R, config={align = "cm", padding = 0.1}, nodes={
+        {n=G.UIT.R, config={align = "cm", padding = 0.25}, nodes={
           {n=G.UIT.R, config={id = 'from_game_over', align = "cm", minw = 5, padding = 0.1, r = 0.1, hover = true, colour = G.C.RED, button = "notify_then_setup_run", shadow = true, focus_args = {nav = 'wide', snap_to = true}}, nodes={
             {n=G.UIT.R, config={align = "cm", padding = 0, no_fill = true, maxw = 4.8}, nodes={
-              {n=G.UIT.T, config={text = localize('b_start_new_run'), scale = 0.5, colour = G.C.UI.TEXT_LIGHT}}
+              {n=G.UIT.T, config={text = localize('b_start_new_run'), scale = 0.7, colour = G.C.UI.TEXT_LIGHT}}
             }}
           }},
           {n=G.UIT.R, config={align = "cm", minw = 5, padding = 0.1, r = 0.1, hover = true, colour = G.C.RED, button = "go_to_menu", shadow = true, focus_args = {nav = 'wide'}}, nodes={
             {n=G.UIT.R, config={align = "cm", padding = 0, no_fill = true, maxw = 4.8}, nodes={
-              {n=G.UIT.T, config={text = localize('b_main_menu'), scale = 0.5, colour = G.C.UI.TEXT_LIGHT}}
-            }}
+              {n=G.UIT.T, config={text = localize('b_main_menu'), scale = 0.7, colour = G.C.UI.TEXT_LIGHT}}
           }}
         }}
+        }},
       }},
     }}
   else
@@ -3112,7 +3131,7 @@ function create_UIBox_game_over()
   if G.F_PORTRAIT then
     t.nodes[1] = {n=G.UIT.R, config={align = "cm", padding = 0.02}, nodes={
       {n=G.UIT.R, config={align = "cm", padding = 0.02}, nodes={t.nodes[1]}},
-      {n=G.UIT.R, config={align = "cm", padding = 0.02}, nodes={
+      {n=G.UIT.R, config={align = "cm", padding = 0.5}, nodes={
         {n=G.UIT.O, config={padding = 0, id = 'jimbo_spot', object = Moveable(0,0,G.CARD_W*0.6, G.CARD_H*0.6)}},
       }}
     }}
@@ -3152,7 +3171,11 @@ function create_UIBox_round_scores_row(score, text_colour)
     }
   end
   if score == 'seed' then 
+    if G.F_PORTRAIT then
+      label_w = 1
+    else
     label_w = 1.9
+    end
     score_w = 1.9
     label = localize('k_seed')
     score_tab = {

--- a/src/functions/UI_definitions.lua
+++ b/src/functions/UI_definitions.lua
@@ -2729,10 +2729,9 @@ function create_UIBox_high_scores()
   G.focused_profile = G.SETTINGS.profile
   local cheevs = {}
 
+  local display = G.UIT.C
   if G.F_PORTRAIT then
     display = G.UIT.R
-  else
-    display = G.UIT.C
   end
   
   local t = create_UIBox_generic_options({ back_func = 'options', snap_back = true, contents = {

--- a/src/functions/button_callbacks.lua
+++ b/src/functions/button_callbacks.lua
@@ -630,19 +630,25 @@ G.FUNCS.your_collection_tarot_page = function(args)
     for i = #G.your_collection[j].cards,1, -1 do
       local c = G.your_collection[j]:remove_card(G.your_collection[j].cards[i])
       c:remove()
-      c = nil
+    end
+  end
+
+  local row_sizes = G.F_PORTRAIT and {3, 4, 4} or {5, 6}
+  local page = args.cycle_config.current_option
+  local card_index = 1 + (page - 1) * 11
+
+  for j = 1, #G.your_collection do
+    for i = 1, row_sizes[j] do
+      local center = G.P_CENTER_POOLS["Tarot"][card_index]
+      if center then 
+        local card = Card(G.your_collection[j].T.x + G.your_collection[j].T.w/2, G.your_collection[j].T.y, G.CARD_W, G.CARD_H, nil, center)
+        card:start_materialize(nil, i>1 or j>1)
+        G.your_collection[j]:emplace(card)
+      end
+      card_index = card_index + 1
     end
   end
   
-  for j = 1, #G.your_collection do
-    for i = 1, 4+j do
-      local center = G.P_CENTER_POOLS["Tarot"][i+(j-1)*(5) + (11*(args.cycle_config.current_option - 1))]
-      if not center then break end
-      local card = Card(G.your_collection[j].T.x + G.your_collection[j].T.w/2, G.your_collection[j].T.y, G.CARD_W, G.CARD_H, G.P_CARDS.empty, center)
-      card:start_materialize(nil, i>1 or j>1)
-      G.your_collection[j]:emplace(card)
-    end
-  end
   INIT_COLLECTION_CARD_ALERTS()
 end
 

--- a/src/functions/common_events.lua
+++ b/src/functions/common_events.lua
@@ -798,11 +798,20 @@ function set_alerts()
 end
 
 function set_main_menu_UI()
+    local x_offset_base = 0
+    local x_offset_plus = 0
+    local y_offset_base = 0
+    if G.F_PORTRAIT then
+        x_offset_base = 0.7
+        x_offset_plus = 0.2
+        y_offset_base = -0.7
+    end
+
     G.MAIN_MENU_UI = UIBox{
         definition = create_UIBox_main_menu_buttons(), 
-        config = {align="bmi", offset = {x=0,y=10}, major = G.ROOM_ATTACH, bond = 'Weak'}
+        config = {align="bmi", offset = {x=x_offset_base*2+x_offset_plus,y=10}, major = G.ROOM_ATTACH, bond = 'Weak'}
     }
-    G.MAIN_MENU_UI.alignment.offset.y = 0
+    G.MAIN_MENU_UI.alignment.offset.y = y_offset_base
     G.MAIN_MENU_UI:align_to_major()
     G.E_MANAGER:add_event(Event({
         blockable = false,
@@ -811,8 +820,8 @@ function set_main_menu_UI()
             if (not G.F_DISP_USERNAME) or (type(G.F_DISP_USERNAME) == 'string') then
                 G.PROFILE_BUTTON = UIBox{
                     definition =  create_UIBox_profile_button(), 
-                        config = {align="bli", offset = {x=-10,y=0}, major = G.ROOM_ATTACH, bond = 'Weak'}}
-                    G.PROFILE_BUTTON.alignment.offset.x = 0
+                        config = {align="bli", offset = {x=-10,y=y_offset_base}, major = G.ROOM_ATTACH, bond = 'Weak'}}
+                    G.PROFILE_BUTTON.alignment.offset.x = x_offset_base
                     G.PROFILE_BUTTON:align_to_major()
                 return true
             end

--- a/src/game.lua
+++ b/src/game.lua
@@ -1576,10 +1576,14 @@ function Game:main_menu(change_context) --True if main menu is accessed from the
         CAI.TITLE_TOP_W,CAI.TITLE_TOP_H,
         {card_limit = 1, type = 'title'})
 
-    
+    local SC_scale_splash = 13*SC_scale
+    if G.F_PORTRAIT then
+        SC_scale_splash = 10*SC_scale
+    end
+
     G.SPLASH_LOGO = Sprite(0, 0, 
-        13*SC_scale, 
-        13*SC_scale*(G.ASSET_ATLAS["balatro"].py/G.ASSET_ATLAS["balatro"].px),
+        SC_scale_splash, 
+        SC_scale_splash*(G.ASSET_ATLAS["balatro"].py/G.ASSET_ATLAS["balatro"].px),
         G.ASSET_ATLAS["balatro"], {x=0,y=0})
 
     G.SPLASH_LOGO:set_alignment({
@@ -1595,8 +1599,12 @@ function Game:main_menu(change_context) --True if main menu is accessed from the
     G.SPLASH_LOGO.dissolve_colours = {G.C.WHITE, G.C.WHITE}
     G.SPLASH_LOGO.dissolve = 1   
 
+    local mult = 1.2
+    if G.F_PORTRAIT then
+        mult = 0.9
+    end
 
-    local replace_card = Card(self.title_top.T.x, self.title_top.T.y, 1.2*G.CARD_W*SC_scale, 1.2*G.CARD_H*SC_scale, G.P_CARDS.S_A, G.P_CENTERS.c_base)
+    local replace_card = Card(self.title_top.T.x, self.title_top.T.y, mult*G.CARD_W*SC_scale, mult*G.CARD_H*SC_scale, G.P_CARDS.S_A, G.P_CENTERS.c_base)
     self.title_top:emplace(replace_card)
 
     replace_card.states.visible = false
@@ -1703,13 +1711,20 @@ function Game:main_menu(change_context) --True if main menu is accessed from the
         end
       }))
 
+    local align_version = "tri"
+    local offset_version = 0
+    if G.F_PORTRAIT then
+        align_version = "tli"
+        offset_version = 0.6
+    end
+
     --VERSION
     UIBox{
         definition = 
         {n=G.UIT.ROOT, config={align = "cm", colour = G.C.UI.TRANSPARENT_DARK}, nodes={
             {n=G.UIT.T, config={text = G.VERSION, scale = 0.3, colour = G.C.UI.TEXT_LIGHT}}
         }}, 
-        config = {align="tri", offset = {x=0,y=0}, major = G.ROOM_ATTACH, bond = 'Weak'}
+        config = {align=align_version, offset = {x=offset_version,y=offset_version}, major = G.ROOM_ATTACH, bond = 'Weak'}
     }
 end
 


### PR DESCRIPTION
### Inventory (Deck)
- The card inventory (by clicking on the deck in game) is now adapted to vertical mode
### Main Menu
- Bigger buttons for the main menu and a little padding between boxes
- Title shrinks to fit on screen
- Version visible on all screens
### Collection, Stats, Credits and Challenges on portait mode
- Buttons header at max 3 if sup to 4 buttons
- Stats on vertical : one column and cards histograms scaled
- Collection : Tarot cards and Planet Cards in 3 rows [3 4 4] and [4 4 4]
- Challenges : one column to fit screen  size, 5 challenges per page
### Win and Game Over layouts
- Jimbo spot under Win box
- New Layout for Game Over screen